### PR TITLE
Multiple binds; graceful shutdown

### DIFF
--- a/example.toml
+++ b/example.toml
@@ -27,8 +27,8 @@ acl = [
     {destination_network = "10.0.0.0/8", action="Reject"},
     {destination_network = "fc00::/7", action="Reject"},
     {destination_network = "fe80::/10", action="Reject"},
-    {destination_network = "127.0.0.0/8", action="Reject"},
-    {destination_network = "::1/128", action="Reject"},
+#    {destination_network = "127.0.0.0/8", action="Reject"},
+#    {destination_network = "::1/128", action="Reject"},
     {destination_port = 443, action = "Allow"},
     {destination_port = 80, action = "Allow"},
     {destination_port = 22, action = "Allow"},
@@ -36,7 +36,7 @@ acl = [
     {username = "backdoor", action = "Allow"},
 ]
 # if no rules in the ACL match, this rule is applied
-acl-default-action = "Reject"
+acl-default-action = "Allow"
 # whether or not to expect the PROXY protocol
 expect-proxy = false
 # whether or not to set SO_REUSEPORT on supported platforms

--- a/example.toml
+++ b/example.toml
@@ -1,8 +1,6 @@
 # this is the address to listen on for incoming sesions; you can also pass a list of addresses
-listen-address = [
-    "[::1]:1080",
-    "[::1]:10080",
-]
+# using regular TOML [ ] list syntax.
+listen-address = "[::1]:1080"
 
 # this is a list of addresses to bind to for outgoing connections. If not passed, it defaults to [0.0.0.0, ::].
 # if you don't pass any IPv4 addresses, IPv4 requests will be deined. Ditto for IPv6.
@@ -27,8 +25,8 @@ acl = [
     {destination_network = "10.0.0.0/8", action="Reject"},
     {destination_network = "fc00::/7", action="Reject"},
     {destination_network = "fe80::/10", action="Reject"},
-#    {destination_network = "127.0.0.0/8", action="Reject"},
-#    {destination_network = "::1/128", action="Reject"},
+    {destination_network = "127.0.0.0/8", action="Reject"},
+    {destination_network = "::1/128", action="Reject"},
     {destination_port = 443, action = "Allow"},
     {destination_port = 80, action = "Allow"},
     {destination_port = 22, action = "Allow"},
@@ -36,11 +34,11 @@ acl = [
     {username = "backdoor", action = "Allow"},
 ]
 # if no rules in the ACL match, this rule is applied
-acl-default-action = "Allow"
+acl-default-action = "Reject"
 # whether or not to expect the PROXY protocol
 expect-proxy = false
 # whether or not to set SO_REUSEPORT on supported platforms
-reuse-port = true
+reuse-port = false
 
 # if this section isn't present, then we use env_logger and log to stderr
 # obeying the $RUST_LOG environment variable

--- a/example.toml
+++ b/example.toml
@@ -1,5 +1,9 @@
-# this is the address to listen on for incoming sesions
-listen-address = "[::1]:8080"
+# this is the address to listen on for incoming sesions; you can also pass a list of addresses
+listen-address = [
+    "[::1]:1080",
+    "[::1]:10080",
+]
+
 # this is a list of addresses to bind to for outgoing connections. If not passed, it defaults to [0.0.0.0, ::].
 # if you don't pass any IPv4 addresses, IPv4 requests will be deined. Ditto for IPv6.
 # 0.0.0.0 and :: are treated as INADDR_ANY (even on platforms where that's not what INADDR_ANY is defined as) and use
@@ -36,7 +40,7 @@ acl-default-action = "Reject"
 # whether or not to expect the PROXY protocol
 expect-proxy = false
 # whether or not to set SO_REUSEPORT on supported platforms
-reuse-port = false
+reuse-port = true
 
 # if this section isn't present, then we use env_logger and log to stderr
 # obeying the $RUST_LOG environment variable

--- a/example.toml
+++ b/example.toml
@@ -15,6 +15,8 @@ bind-addresses = [
 connect-timeout-ms = 3000
 # this timeout is applied to the entire request
 total-timeout-ms = 1800000
+# this timeout controls how long to wait for in-flight sessions after getting SIGTERM
+shutdown-timeout-ms = 10000
 # this address is listened to for stats requests. if it starts with /, it is a stream-mode UNIX domain socket;
 # otherwise, it is a TCP socket address
 stats-socket-listen-address = "[::1]:8081"

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,10 +195,6 @@ impl ListenAddress {
     pub fn iter(&self) -> ListenAddressIter {
         ListenAddressIter::new(self)
     }
-
-    pub fn is_ipv6(&self) -> bool {
-        self.iter().any(SocketAddr::is_ipv6)
-    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,10 +44,6 @@ fn _default_bind() -> Vec<IpAddr> {
     ]
 }
 
-fn _default_connect_timeout_ms() -> u32 {
-    3000
-}
-
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[allow(non_camel_case_types)]
 pub enum SyslogFacility {
@@ -207,10 +203,12 @@ pub struct RawConfig {
     pub acl: Vec<AclItem>,
     #[serde(alias = "acl-default-action")]
     pub acl_default_action: AclAction,
-    #[serde(alias = "connect-timeout-ms", default = "_default_connect_timeout_ms")]
-    pub connect_timeout_ms: u32,
+    #[serde(alias = "connect-timeout-ms")]
+    pub connect_timeout_ms: Option<u32>,
     #[serde(alias = "total-timeout-ms")]
     pub total_timeout_ms: Option<u32>,
+    #[serde(alias = "shutdown-timeout-ms")]
+    pub shutdown_timeout_ms: Option<u32>,
     #[serde(alias = "stats-socket-listen-address")]
     pub stats_socket_listen_address: Option<String>,
     #[serde(alias = "expect-proxy", default = "_false")]
@@ -236,6 +234,7 @@ pub struct Config {
     pub acl: Acl,
     pub connect_timeout_ms: u32,
     pub total_timeout_ms: Option<u32>,
+    pub shutdown_timeout_ms: u64,
     pub stats_socket_listen_address: Option<String>,
     pub expect_proxy: bool,
     pub reuse_port: bool,
@@ -249,8 +248,9 @@ impl Config {
             listen_address: raw.listen_address,
             bind_addresses: raw.bind_addresses,
             acl: Acl::from_parts(raw.acl, raw.acl_default_action),
-            connect_timeout_ms: raw.connect_timeout_ms,
+            connect_timeout_ms: raw.connect_timeout_ms.unwrap_or(10_000),
             total_timeout_ms: raw.total_timeout_ms,
+            shutdown_timeout_ms: u64::from(raw.shutdown_timeout_ms.unwrap_or(5_000)),
             stats_socket_listen_address: raw.stats_socket_listen_address,
             expect_proxy: raw.expect_proxy,
             reuse_port: raw.reuse_port,

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,7 +522,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             #[cfg(all(unix, not(any(target_os = "solaris"))))]
             let listener = listener
                 .reuse_port(conf.reuse_port)
-                .expect("failed to set SO_REUSEPORT")
+                .expect("failed to set SO_REUSEPORT");
+
+            let listener = listener
                 .bind(addr)
                 .expect(format!("failed to bind to {:?}", addr).as_str());
             info!("Listening on: {}", addr);

--- a/src/main.rs
+++ b/src/main.rs
@@ -433,6 +433,9 @@ async fn handle_connections(
             }
         }
     }
+    // eagerly drop the stream to shut down the listening socket
+    drop(stream);
+    drop(listener);
     // this is cheesy. we should probably have something other than time-based
     // polling here.
     while outstanding.load(Ordering::Relaxed) != 0 {


### PR DESCRIPTION
This branch has two big features:

 - binding to multiple addresses (originally I did this with multiple `bind` calls on the same socket, but that doesn't work with multiple address families, so now it just make multiple listening sockets)
 - graceful shutdown, where the program catches SIGINT and SIGTERM and, on receipt, shuts down the listening socket and waits for all in-flight sessions to die before shutting down

It also greatly refactors how the main loop works, moving the incoming stream handling into a separate Tokio task.

I've done a fair bit of testing and everything seems to work correctly.