### PR TITLE
include local addr and peer addr in in-flight set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -309,6 +309,7 @@ async fn handle_one_connection(
         };
         let remote_end = conn.peer_addr()?;
         let local_end = conn.local_addr()?;
+        stats.set_connection(conn_id, local_end, remote_end).await;
         info!(
             "{}: connected to {:?} from {:?}",
             conn_id, remote_end, local_end


### PR DESCRIPTION
This includes the SocketAddr (IP address + port) of the actual TCP socket in the `sessions` map in the stats socket.

Example:

```json
{
  "handshake_failed": 0,
  "handshake_success": 1,
  "handshake_timeout": 0,
  "session_success": 0,
  "session_error": 0,
  "session_timeout": 0,
  "connection_connected": 1,
  "connection_not_allowed": 0,
  "connection_address_not_supported": 0,
  "connection_socks_failure": 0,
  "connection_network_unreachable": 0,
  "in_flight": 1,
  "sessions": {
    "1": {
      "source_address": "[::1]:62240",
      "request": {
        "address": "www.easypost.com",
        "dport": 80,
        "ver": "5",
        "username": null
      },
      "connection": {
        "local_end": "[2601:644:1:727d:ad2e:4961:9110:1fb3]:62241",
        "remote_end": "[2607:f0d0:3803:ca::9]:80"
      },
      "start_time": {
        "ts": 1599616800.439918,
        "ago": 0.08985
      }
    }
  }
}
```

This is useful for debugging exactly which IP address a client has connected to, particularly when the request is a hostname (e.g., `socks5h` mode) and it might be a round-robin.