### PR TITLE
2022 upgrades for ferrous-socks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ env:
 
 jobs:
   style:
-    name: Check Style
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -50,7 +49,14 @@ jobs:
         toolchain: stable
         components: rustfmt
         default: true
-    - name: cargo audit
-      uses: actions-rs/audit-check@v1.2.0
+    - name: Install cargo-audit binary crate
+      uses: actions-rs/install@v0.1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        crate: cargo-audit
+        version: latest
+        use-tool-cache: true
+    - name: cargo audit
+      uses: actions-rs/cargo@v1
+      with:
+        command: audit
+        args: --ignore RUSTSEC-2020-0071

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "derive_more",
  "env_logger",
  "futures",
+ "hex-literal",
  "ip_network",
  "log",
  "permit",
@@ -240,6 +241,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "humantime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,19 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.41"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
 name = "atty"
@@ -45,9 +36,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "byteorder"
@@ -57,9 +48,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cfg-if"
@@ -69,17 +60,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -90,9 +82,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "derive_more"
-version = "0.99.16"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -135,19 +127,21 @@ dependencies = [
  "futures",
  "ip_network",
  "log",
+ "permit",
  "serde",
- "serde_derive",
  "serde_json",
  "syslog",
+ "thiserror",
  "tokio",
+ "tokio-stream",
  "toml",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -160,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -170,15 +164,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -187,18 +181,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -206,23 +198,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -232,10 +223,14 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hermit-abi"
@@ -256,10 +251,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.9"
+name = "indexmap"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
@@ -275,21 +280,27 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -305,15 +316,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
@@ -342,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -352,15 +363,24 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -369,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if",
  "instant",
@@ -382,19 +402,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest"
-version = "2.1.3"
+name = "permit"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
+checksum = "c6eef06a57b28b8d7b6ea6ee1ba69428350f4d3fca8b91ff10ad2b43bd73a272"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -403,22 +420,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -431,18 +436,18 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -466,18 +471,18 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "scopeguard"
@@ -487,33 +492,24 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -522,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa",
  "ryu",
@@ -542,27 +538,27 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -592,11 +588,28 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
- "unicode-width",
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -612,11 +625,10 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -632,13 +644,24 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -651,34 +674,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,25 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,7 +103,6 @@ dependencies = [
  "anyhow",
  "byteorder",
  "clap",
- "derive_more",
  "env_logger",
  "futures",
  "hex-literal",
@@ -477,15 +457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,12 +467,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ ip_network = { version = "0.3", features = ["serde"] }
 serde_json = "1"
 syslog = "5"
 thiserror = "1"
+
+[dev-dependencies]
+hex-literal = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,17 @@ repository = "https://github.com/EasyPost/ferrous-socks"
 [dependencies]
 anyhow = "1.0"
 tokio = { version = "^1.5", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["net"] }
 futures = "0.3"
 derive_more = "0.99"
 byteorder = "1"
 log = "0.4"
 env_logger = "0.7"
-clap = "2"
+clap = { version = "3", features = ["color", "cargo", "env"] }
+permit = "0.1.4"
 toml = "0.5"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1", features = ["derive"] }
 ip_network = { version = "0.3", features = ["serde"] }
 serde_json = "1"
 syslog = "5"
-
-[badges]
-travis-ci = { repository = "EasyPost/ferrous-socks", branch = "master" }
+thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0"
 tokio = { version = "^1.5", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 futures = "0.3"
-derive_more = "0.99"
 byteorder = "1"
 log = "0.4"
 env_logger = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ferrous-socks"
 version = "1.0.5"
 authors = ["James Brown <jbrown@easypost.com>"]
-edition = "2018"
+edition = "2021"
 license = "ISC"
 readme = "README.md"
 repository = "https://github.com/EasyPost/ferrous-socks"

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Features:
  - basic SOCKS4 and SOCKS4a support (username parameter is ignored)
  - will accept any username+password authentication (and log the username)
 
-Check out [example.toml](example.toml) for an example of what the config file looks like.
+Check out [example.toml](example.toml) for an example of what the config file looks like. You can generate the default config by running `ferrous-socks --dump-config default.toml`

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -1,8 +1,8 @@
 use ip_network::IpNetwork;
-use serde_derive::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy)]
 pub enum AclAction {
     Allow,
     Reject,
@@ -23,7 +23,7 @@ impl Default for AclAction {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AclItem {
     pub action: AclAction,
     pub destination_network: Option<IpNetwork>,
@@ -43,6 +43,10 @@ impl Acl {
             items,
             default_action,
         }
+    }
+
+    pub fn into_parts(self) -> (Vec<AclItem>, AclAction) {
+        (self.items, self.default_action)
     }
 
     pub fn is_permitted(&self, username: Option<&str>, ip: IpAddr, dport: u16) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,29 +7,17 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::time::Duration;
 
-use derive_more::Display;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::acl::{Acl, AclAction, AclItem};
 
-#[derive(Debug, Display)]
+#[derive(Debug, Error)]
 pub enum ConfigError {
-    IoError(std::io::Error),
-    DeserializationError(toml::de::Error),
-}
-
-impl std::error::Error for ConfigError {}
-
-impl From<std::io::Error> for ConfigError {
-    fn from(e: std::io::Error) -> Self {
-        ConfigError::IoError(e)
-    }
-}
-
-impl From<toml::de::Error> for ConfigError {
-    fn from(e: toml::de::Error) -> Self {
-        ConfigError::DeserializationError(e)
-    }
+    #[error("I/O error reading configuration: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Deserialization error reading configuration: {0}")]
+    Deserialization(#[from] toml::de::Error),
 }
 
 fn _true() -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,14 @@
+use std::convert::TryInto;
 use std::fs::File;
 use std::fs::Permissions;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+use std::time::Duration;
 
 use derive_more::Display;
-use serde_derive::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::acl::{Acl, AclAction, AclItem};
 
@@ -49,7 +51,7 @@ fn _default_mode() -> u32 {
     0o600
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy)]
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum SyslogFacility {
@@ -105,7 +107,7 @@ impl From<SyslogFacility> for syslog::Facility {
     }
 }
 
-#[derive(Debug, Deserialize, Copy, Clone)]
+#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum LogLevel {
@@ -114,12 +116,6 @@ pub enum LogLevel {
     INFO,
     DEBUG,
     TRACE,
-}
-
-impl Default for LogLevel {
-    fn default() -> Self {
-        LogLevel::INFO
-    }
 }
 
 impl From<LogLevel> for log::LevelFilter {
@@ -134,25 +130,21 @@ impl From<LogLevel> for log::LevelFilter {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SyslogConfig {
     pub facility: SyslogFacility,
-    #[serde(default)]
-    pub level: LogLevel,
+    pub level: Option<LogLevel>,
 }
 
 impl SyslogConfig {
-    pub fn initialize_logging(&self) {
-        syslog::init(
-            self.facility.into(),
-            self.level.into(),
-            Some(env!("CARGO_PKG_NAME")),
-        )
-        .expect("failed to initialize syslog");
+    pub fn initialize_logging(&self, level: log::LevelFilter) {
+        let level = self.level.map(|l| l.into()).unwrap_or(level);
+        syslog::init(self.facility.into(), level, Some(env!("CARGO_PKG_NAME")))
+            .expect("failed to initialize syslog");
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ListenAddress {
     One(SocketAddr),
@@ -200,7 +192,7 @@ impl ListenAddress {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RawConfig {
     #[serde(alias = "listen-address")]
@@ -217,6 +209,8 @@ pub struct RawConfig {
     pub total_timeout_ms: Option<u32>,
     #[serde(alias = "shutdown-timeout-ms")]
     pub shutdown_timeout_ms: Option<u32>,
+    #[serde(alias = "proxy-protocol-timeout-ms")]
+    pub proxy_protocol_timeout_ms: Option<u32>,
     #[serde(alias = "stats-socket-listen-address")]
     pub stats_socket_listen_address: Option<String>,
     #[serde(alias = "stats-socket-mode", default = "_default_mode")]
@@ -228,6 +222,29 @@ pub struct RawConfig {
     pub syslog: Option<SyslogConfig>,
 }
 
+impl Default for RawConfig {
+    fn default() -> Self {
+        RawConfig {
+            listen_address: ListenAddress::One(SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                1080,
+            )),
+            bind_addresses: _default_bind(),
+            acl: vec![],
+            acl_default_action: AclAction::Allow,
+            connect_timeout_ms: None,
+            total_timeout_ms: None,
+            shutdown_timeout_ms: None,
+            proxy_protocol_timeout_ms: None,
+            stats_socket_listen_address: None,
+            stats_socket_mode: _default_mode(),
+            expect_proxy: false,
+            reuse_port: false,
+            syslog: None,
+        }
+    }
+}
+
 impl RawConfig {
     fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
         let mut f = File::open(path)?;
@@ -236,15 +253,35 @@ impl RawConfig {
         let config = toml::from_str(contents.as_str())?;
         Ok(config)
     }
+
+    fn dump_to<W: std::io::Write>(&self, f: W) -> anyhow::Result<()> {
+        let v = toml::ser::to_vec(self)?;
+        let mut b = std::io::BufWriter::new(f);
+        b.write_all(&v)?;
+        Ok(())
+    }
+
+    /// Dump the given config to the path. If the path is None, will dump to stdout.
+    pub fn dump<P: AsRef<Path>>(&self, path: Option<P>) -> anyhow::Result<()> {
+        if let Some(path) = path {
+            let f = File::create(path.as_ref())?;
+            self.dump_to(f)
+        } else {
+            let stdout = std::io::stdout();
+            let f = stdout.lock();
+            self.dump_to(f)
+        }
+    }
 }
 
 pub struct Config {
     pub listen_address: ListenAddress,
     pub bind_addresses: Vec<IpAddr>,
     pub acl: Acl,
-    pub connect_timeout_ms: u32,
-    pub total_timeout_ms: Option<u32>,
-    pub shutdown_timeout_ms: u64,
+    pub connect_timeout: Duration,
+    pub total_timeout: Option<Duration>,
+    pub shutdown_timeout: Duration,
+    pub proxy_protocol_timeout: Duration,
     pub stats_socket_listen_address: Option<String>,
     pub stats_socket_mode: Permissions,
     pub expect_proxy: bool,
@@ -252,29 +289,84 @@ pub struct Config {
     pub syslog_config: Option<SyslogConfig>,
 }
 
+fn ms_with_default(val: Option<u32>, default: u32) -> Duration {
+    Duration::from_millis(u64::from(val.unwrap_or(default)))
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::from_raw(RawConfig::default())
+    }
+}
+
 impl Config {
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
-        let raw = RawConfig::from_path(path)?;
-        Ok(Config {
+    pub fn from_raw(raw: RawConfig) -> Self {
+        Config {
             listen_address: raw.listen_address,
             bind_addresses: raw.bind_addresses,
             acl: Acl::from_parts(raw.acl, raw.acl_default_action),
-            connect_timeout_ms: raw.connect_timeout_ms.unwrap_or(10_000),
-            total_timeout_ms: raw.total_timeout_ms,
-            shutdown_timeout_ms: u64::from(raw.shutdown_timeout_ms.unwrap_or(5_000)),
+            connect_timeout: ms_with_default(raw.connect_timeout_ms, 10_000),
+            total_timeout: raw
+                .total_timeout_ms
+                .map(|d| Duration::from_millis(u64::from(d))),
+            shutdown_timeout: ms_with_default(raw.shutdown_timeout_ms, 5_000),
+            proxy_protocol_timeout: ms_with_default(raw.proxy_protocol_timeout_ms, 1_000),
             stats_socket_listen_address: raw.stats_socket_listen_address,
             stats_socket_mode: Permissions::from_mode(raw.stats_socket_mode),
             expect_proxy: raw.expect_proxy,
             reuse_port: raw.reuse_port,
             syslog_config: raw.syslog,
-        })
+        }
     }
 
-    pub fn initialize_logging(&self) {
-        if let Some(ref c) = self.syslog_config {
-            c.initialize_logging()
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
+        let raw = RawConfig::from_path(path)?;
+        Ok(Self::from_raw(raw))
+    }
+
+    fn into_raw(self) -> RawConfig {
+        let (acl, acl_default_action) = self.acl.into_parts();
+        RawConfig {
+            listen_address: self.listen_address,
+            bind_addresses: self.bind_addresses,
+            acl,
+            acl_default_action,
+            connect_timeout_ms: Some(self.connect_timeout.as_millis().try_into().unwrap()),
+            total_timeout_ms: self
+                .total_timeout
+                .map(|d| d.as_millis().try_into().unwrap()),
+            shutdown_timeout_ms: Some(self.shutdown_timeout.as_millis().try_into().unwrap()),
+            proxy_protocol_timeout_ms: Some(
+                self.proxy_protocol_timeout.as_millis().try_into().unwrap(),
+            ),
+            stats_socket_listen_address: self.stats_socket_listen_address,
+            stats_socket_mode: self.stats_socket_mode.mode(),
+            expect_proxy: self.expect_proxy,
+            reuse_port: self.reuse_port,
+            syslog: self.syslog_config,
+        }
+    }
+
+    pub fn dump<P: AsRef<Path>>(self, path: Option<P>) -> anyhow::Result<()> {
+        self.into_raw().dump(path)
+    }
+
+    pub fn initialize_logging(&self, matches: &clap::ArgMatches) {
+        let level: log::LevelFilter = matches
+            .value_of_t_or_exit::<String>("log_level")
+            .parse()
+            .expect("Invalid --log-level");
+        // this is gross but semantically equivalnet to the illegal `if let Some(ref c) = self.syslog_config && !matches.is_present("stderr")`
+        if let Some(c) = (!matches.is_present("stderr"))
+            .then(|| self.syslog_config.as_ref())
+            .flatten()
+        {
+            c.initialize_logging(level)
         } else {
-            env_logger::init()
+            env_logger::Builder::new()
+                .filter_level(level)
+                .format_timestamp_secs()
+                .init();
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::fs::File;
 use std::fs::Permissions;
 use std::io::{Read, Write};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,495 +1,134 @@
 use std::env;
-use std::error::Error;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use anyhow::Context;
-use byteorder::{ByteOrder, NetworkEndian};
-use clap::{self, Arg};
-use derive_more::Display;
+use clap::Arg;
 use futures::future::FutureExt;
-use futures::stream::StreamExt;
-use log::{debug, error, info, warn};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
-use tokio::signal::unix::SignalKind;
+use log::{debug, info, warn};
+use tokio::signal::unix::{signal, SignalKind};
 
 mod acl;
 mod config;
 mod proxy;
 mod reply;
 mod request;
+mod socks;
 mod stats;
 mod stats_socket;
 mod util;
 
 use config::Config;
-use reply::Reply;
-use request::{Address, Connection, Request, Version};
 
-const LISTEN_BACKLOG: u32 = 128;
-
-enum HandshakeResult {
-    Okay,
-    AuthenticatedAs(String),
-    Failed,
-    Version4([u8; 2]),
-}
-
-async fn authenticate_rfc1929(socket: &mut TcpStream) -> Result<Option<String>, tokio::io::Error> {
-    let mut buf = [0u8; 2];
-    socket.read_exact(&mut buf).await?;
-    // VER = 0x01
-    if buf[0] != 0x01 {
-        return Ok(None);
-    }
-    let mut username = vec![0u8; buf[1] as usize];
-    socket.read_exact(&mut username).await?;
-    let mut password_len = [0u8; 1];
-    socket.read_exact(&mut password_len).await?;
-    let mut password = vec![0u8; password_len[0] as usize];
-    socket.read_exact(&mut password).await?;
-    socket.write_all(&[0x1u8, 0x0u8]).await?;
-    Ok(Some(String::from_utf8_lossy(&username).into_owned()))
-}
-
-/// Perform the RFC1928 authentication handshake
-///
-/// Prerequisite: Nothing has been read from the socket yet
-///
-/// If returns HandshakeResult::Failed, the stream should be closed. Otherwise,
-/// we are (to some degree) authenticated.
-async fn handshake_auth(socket: &mut TcpStream) -> Result<HandshakeResult, tokio::io::Error> {
-    // If this is SOCKS4, the first byte is 0x04 and the second byte is actually not part of the
-    // handshake. Oops!
-    let mut init_buf = [0u8; 2];
-    socket.read_exact(&mut init_buf).await?;
-    if init_buf[0] == 0x04 {
-        return Ok(HandshakeResult::Version4(init_buf));
-    }
-    // If this is SOCKS5, the first byte is 0x05 and the second byte is the number of auth
-    // mechanisms supported
-    if init_buf[0] != 0x05 {
-        socket.write_all(&[0x05u8, 0xff]).await?;
-        return Ok(HandshakeResult::Failed);
-    }
-    let num_auths = init_buf[1];
-    if num_auths > 0xfe {
-        socket.write_all(&[0x05u8, 0xff]).await?;
-        return Ok(HandshakeResult::Failed);
-    }
-    // Each auth mechanism is a single byte
-    let mut auths = vec![0u8; num_auths as usize];
-    socket.read_exact(&mut auths).await?;
-    // Try more sophisticated (higher-valued) auth mechanisms first
-    auths.sort_by(|a, b| b.cmp(a));
-    for auth in auths {
-        if auth == 0u8 {
-            // 0x00 == unauthenticated. great
-            socket.write_all(&[0x5u8, 0x00u8]).await?;
-            return Ok(HandshakeResult::Okay);
-        } else if auth == 0x02u8 {
-            // 0x02 = username+password auth as per RFC1929
-            socket.write_all(&[0x5u8, 0x2u8]).await?;
-            if let Some(username) = authenticate_rfc1929(socket).await? {
-                return Ok(HandshakeResult::AuthenticatedAs(username));
-            } else {
-                warn!("1929 authentication failed; aborting");
-                socket.write_all(&[0x1u8, 0xffu8]).await?;
-            }
-        }
-    }
-    // if we get here, we didn't have any supported auth mechainisms. oops.
-    socket.write_all(&[0x5u8, 0xffu8]).await?;
-    Ok(HandshakeResult::Failed)
-}
-
-#[derive(Debug, Display)]
-enum RequestError {
-    BadAddressType,
-    IoError(tokio::io::Error),
-}
-
-impl Error for RequestError {}
-
-impl From<tokio::io::Error> for RequestError {
-    fn from(t: tokio::io::Error) -> Self {
-        RequestError::IoError(t)
-    }
-}
-
-/// Read a SOCKSv4 or SOCKSv5 request from the stream
-async fn read_request(
-    socket: &mut TcpStream,
-    already_read: Option<[u8; 2]>,
-) -> Result<Option<Request>, RequestError> {
-    let (ver, cmd, addr_type) = if let Some(already_read) = already_read {
-        (already_read[0], already_read[1], 0x01u8)
-    } else {
-        let mut fixed_buf = [0u8; 4];
-        socket.read_exact(&mut fixed_buf).await?;
-        let ver = fixed_buf[0];
-        let cmd = fixed_buf[1];
-        let addr_type = fixed_buf[3];
-        (ver, cmd, addr_type)
-    };
-    let version = match ver {
-        4 => Version::Four,
-        5 => Version::Five,
-        _ => {
-            Reply::SocksFailure
-                .write_error(socket, Version::Five)
-                .await?;
-            return Ok(None);
-        }
-    };
-    let request = match version {
-        Version::Four => {
-            let mut buf = [0u8; 6];
-            socket.read_exact(&mut buf).await?;
-            let mut ip_buf = [0u8; 4];
-            ip_buf.copy_from_slice(&buf[2..6]);
-            let dport = NetworkEndian::read_u16(&buf[0..2]);
-            let ip_addr: Ipv4Addr = ip_buf.into();
-            let mut username = Vec::new();
-            let mut buf = [0u8; 1];
-            loop {
-                socket.read_exact(&mut buf).await?;
-                if buf[0] == 0x0 {
-                    break;
-                }
-                username.push(buf[0]);
-            }
-            let address = if ip_addr.octets()[0..3] == [0, 0, 0] {
-                let mut addr_buf = Vec::new();
-                loop {
-                    socket.read_exact(&mut buf).await?;
-                    if buf[0] == 0x0 {
-                        break;
-                    }
-                    addr_buf.push(buf[0]);
-                }
-                Address::DomainName(String::from_utf8_lossy(&addr_buf).into_owned())
-            } else {
-                Address::IpAddr(IpAddr::V4(ip_addr))
-            };
-            Request::new(
-                address,
-                dport,
-                version,
-                Some(String::from_utf8_lossy(&username).into_owned()),
-            )
-        }
-        Version::Five => {
-            let address = match addr_type {
-                0x01 => {
-                    let mut buf = [0u8; 4];
-                    socket.read_exact(&mut buf).await?;
-                    Address::IpAddr(IpAddr::V4(buf.into()))
-                }
-                0x03 => {
-                    let mut len_buf = [0u8; 1];
-                    socket.read_exact(&mut len_buf).await?;
-                    let mut name = vec![0u8; len_buf[0] as usize];
-                    socket.read_exact(&mut name).await?;
-                    Address::DomainName(String::from_utf8_lossy(&name).into_owned())
-                }
-                0x04 => {
-                    let mut buf = [0u8; 16];
-                    socket.read_exact(&mut buf).await?;
-                    Address::IpAddr(IpAddr::V6(buf.into()))
-                }
-                _ => return Err(RequestError::BadAddressType),
-            };
-            let mut port_buf = [0u8; 2];
-            socket.read_exact(&mut port_buf).await?;
-            let dport = NetworkEndian::read_u16(&port_buf);
-            Request::new(address, dport, version, None)
-        }
-    };
-    if cmd != 0x01 {
-        Reply::CommandNotSupported
-            .write_error(socket, Version::Five)
-            .await?;
-        return Ok(None);
-    }
-    Ok(Some(request))
-}
-
-async fn handle_one_connection(
-    mut socket: TcpStream,
-    address: SocketAddr,
-    config: Arc<Config>,
-    stats: &stats::Stats,
-    conn_id: u64,
-) -> Result<bool, Box<dyn Error>> {
-    let address = if config.expect_proxy {
-        let header = proxy::read_proxy_header(&mut socket, address).await?;
-        header.source_address
-    } else {
-        address
-    };
-    debug!("{}: accepted connection from {:?}", conn_id, address);
-    let mut username = None;
-    let already_read = match handshake_auth(&mut socket).await? {
-        HandshakeResult::Okay => None,
-        HandshakeResult::AuthenticatedAs(u) => {
-            stats.handshake_authenticated();
-            username = Some(u);
-            None
-        }
-        HandshakeResult::Failed => {
-            stats.handshake_failed();
-            debug!("{}: handshake failed", conn_id);
-            return Ok(false);
-        }
-        HandshakeResult::Version4(bytes) => Some(bytes),
-    };
-    stats.handshake_success();
-    debug!("{}: handshake succeeded", conn_id);
-    let request = read_request(&mut socket, already_read).await?;
-    if let Some(mut request) = request {
-        request.set_username(username);
-        if let Some(ref u) = request.username {
-            debug!("{}: authenticated as {:?}", conn_id, u);
-        } else {
-            debug!("{}: unauthenticated", conn_id);
-        }
-        let version = request.ver;
-        stats.set_request(conn_id, &request).await;
-        let mut conn = match tokio::time::timeout(
-            Duration::from_millis(config.connect_timeout_ms.into()),
-            request.clone().connect(&config),
-        )
-        .await
-        {
-            Ok(c) => {
-                stats.record_connection(&c);
-                match c {
-                    Ok(Connection::Connected(c)) => c,
-                    Ok(Connection::ConnectionNotAllowed) => {
-                        warn!("{}: denying connection to {:?}", conn_id, request);
-                        Reply::ConnectionNotAllowed
-                            .write_error(&mut socket, version)
-                            .await?;
-                        return Ok(false);
-                    }
-                    Ok(Connection::AddressNotSupported) => {
-                        warn!("{}: bad address family to {:?}", conn_id, request);
-                        Reply::AddressNotSupported
-                            .write_error(&mut socket, version)
-                            .await?;
-                        return Ok(false);
-                    }
-                    Ok(Connection::SocksFailure) => {
-                        warn!("{}: failure (resolution?) to {:?}", conn_id, request);
-                        Reply::SocksFailure
-                            .write_error(&mut socket, version)
-                            .await?;
-                        return Ok(false);
-                    }
-                    Err(e) => {
-                        Reply::NetworkUnreachable
-                            .write_error(&mut socket, version)
-                            .await?;
-                        warn!("error connecting: {:?}", e);
-                        return Ok(false);
-                    }
-                }
-            }
-            Err(e) => {
-                warn!("{}: timeout connecting: {:?}", conn_id, e);
-                Reply::TtlExpired.write_error(&mut socket, version).await?;
-                stats.handshake_timeout();
-                return Ok(false);
-            }
-        };
-        let remote_end = conn.peer_addr()?;
-        let local_end = conn.local_addr()?;
-        stats.set_connection(conn_id, local_end, remote_end).await;
-        info!(
-            "{}: connected to {:?} from {:?}",
-            conn_id, remote_end, local_end
-        );
-        match version {
-            Version::Five => {
-                socket
-                    .write_all(&[
-                        0x05,
-                        0x00,
-                        0x00,
-                        match local_end {
-                            SocketAddr::V4(_) => 0x01,
-                            SocketAddr::V6(_) => 0x04,
-                        },
-                    ])
-                    .await?;
-                match local_end.ip() {
-                    IpAddr::V4(i) => socket.write_all(&i.octets()).await?,
-                    IpAddr::V6(i) => socket.write_all(&i.octets()).await?,
-                };
-                let mut buf = [0u8; 2];
-                NetworkEndian::write_u16(&mut buf, local_end.port());
-                socket.write_all(&buf).await?;
-            }
-            Version::Four => {
-                socket
-                    .write_all(&[0x00, 0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
-                    .await?;
-            }
-        }
-        let (stoc, ctos) = tokio::io::copy_bidirectional(&mut conn, &mut socket).await?;
-        stats.record_traffic(stoc, ctos);
-        Ok(true)
-    } else {
-        Ok(false)
-    }
-}
-
-async fn handle_one_connection_wrapper(
-    socket: TcpStream,
-    address: SocketAddr,
-    config: Arc<Config>,
-    stats: Arc<stats::Stats>,
-) {
-    let conn_id = stats.start_request(address).await;
-    if let Some(total_timeout_ms) = config.total_timeout_ms {
-        let timeout = Duration::from_millis(total_timeout_ms.into());
-        match tokio::time::timeout(
-            timeout,
-            handle_one_connection(socket, address, config, &stats, conn_id),
-        )
-        .await
-        {
-            Ok(Ok(_)) => {
-                stats.session_success();
-            }
-            Ok(Err(e)) => {
-                stats.session_error();
-                error!("error handling session {}: {:?}", conn_id, e);
-            }
-            Err(_) => {
-                warn!("session {} timed out!", conn_id);
-                stats.session_timeout();
-            }
-        }
-    } else {
-        match handle_one_connection(socket, address, config, &stats, conn_id).await {
-            Ok(_) => {
-                stats.session_success();
-            }
-            Err(e) => {
-                stats.session_error();
-                error!("error handling session {}: {:?}", conn_id, e);
-            }
-        }
-    }
-    info!("{}: finishing request", conn_id);
-    stats.finish_request(conn_id).await;
-}
-
-async fn handle_connections(
-    listener: TcpListener,
-    conf: Arc<Config>,
-    stats: Arc<stats::Stats>,
-) -> Result<(), tokio::io::Error> {
-    let mut interrupt_signal = tokio::signal::unix::signal(SignalKind::interrupt())?;
-    let mut term_signal = tokio::signal::unix::signal(SignalKind::terminate())?;
-
-    let outstanding = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-
-    loop {
-        tokio::select! {
-            _ = interrupt_signal.recv() => {
-                info!("got signal in listener");
-                break;
-            }
-            _ = term_signal.recv() => {
-                info!("got signal in listener");
-                break;
-            }
-            res = listener.accept() => {
-                let (socket, address) = match res {
-                    Ok(v) => v,
-                    Err(e) => {
-                        error!("Error accepting: {:?}", e);
-                        break
-                    }
-                };
-
-                let my_config = Arc::clone(&conf);
-                let my_stats = Arc::clone(&stats);
-                let my_outstanding = Arc::clone(&outstanding);
-
-                my_outstanding.fetch_add(1, Ordering::SeqCst);
-                tokio::spawn(
-                    handle_one_connection_wrapper(socket, address, my_config, my_stats).map(
-                        move |r| {
-                            my_outstanding.fetch_sub(1, Ordering::SeqCst);
-                            r
-                        },
-                    ),
-                );
-            }
-        };
-    }
-    // eagerly drop the stream to shut down the listening socket
-    drop(listener);
-    // this is cheesy. we should probably have something other than time-based
-    // polling here.
-    let start_poll = Instant::now();
-    let expiration = Duration::from_millis(conf.shutdown_timeout_ms);
-    while outstanding.load(Ordering::Relaxed) != 0 {
-        if start_poll.elapsed() > expiration {
-            warn!("giving up on outstanding sockets and exiting anyway!");
-            break;
-        }
-        debug!("waiting for outstanding tasks to exit");
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
-    Ok(())
-}
-
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let matches = clap::App::new(env!("CARGO_PKG_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("EasyPost <oss@easypost.com>")
-        .about(env!("CARGO_PKG_DESCRIPTION"))
+fn cli() -> clap::App<'static> {
+    clap::App::new(clap::crate_name!())
+        .version(clap::crate_version!())
+        .author(clap::crate_authors!())
+        .about(clap::crate_description!())
         .arg(
-            Arg::with_name("config")
-                .short("c")
+            Arg::new("config")
+                .short('c')
                 .long("config")
                 .value_name("PATH")
                 .help("Path to configuration TOML file")
                 .takes_value(true)
-                .required(true),
+                .required_unless_present("dump-config"),
         )
         .arg(
-            Arg::with_name("check-config")
-                .short("C")
+            Arg::new("check-config")
+                .short('C')
                 .long("check-config")
-                .help("Only check config syntax and exit"),
+                .help("Only check config syntax and exit")
+                .conflicts_with("dump-config")
         )
-        .get_matches();
+        .arg(
+            Arg::new("dump-config")
+                .long("dump-config")
+                .value_name("PATH")
+                .takes_value(true)
+                .help("Dump out config (with all defaults interpolated) to the given path (- meaning stdout)"),
+        )
+        .help_heading("LOGGING OPTIONS")
+        .arg(
+            Arg::new("log_level")
+                .short('L')
+                .long("log-level")
+                .takes_value(true)
+                .default_value("warn")
+                .possible_values(&["error", "warn", "info", "debug", "trace"])
+                .help("Log level (only used if log level not set for syslog in config)"),
+        )
+        .arg(
+            Arg::new("stderr")
+                .short('E')
+                .long("stderr")
+                .help("Force logging to stderr"),
+        )
+}
 
-    let conf = Arc::new(Config::from_path(matches.value_of("config").unwrap())?);
+async fn any_shutdown_signal() {
+    debug!("Will shut down on HUP, QUIT, INT, or TERM");
+    futures::future::select_all(
+        vec![
+            signal(SignalKind::hangup()).unwrap().recv().boxed(),
+            signal(SignalKind::quit()).unwrap().recv().boxed(),
+            signal(SignalKind::interrupt()).unwrap().recv().boxed(),
+            signal(SignalKind::terminate()).unwrap().recv().boxed(),
+        ]
+        .into_iter(),
+    )
+    .await;
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let matches = cli().get_matches();
+
+    let conf = if let Some(config_path) = matches.value_of("config") {
+        Config::from_path(config_path)?
+    } else {
+        Config::default()
+    };
+
+    if let Some(dump_path) = matches.value_of("dump-config") {
+        let dump_path = if dump_path == "-" {
+            None
+        } else {
+            Some(dump_path)
+        };
+        conf.dump(dump_path)?;
+        if let Some(path) = dump_path {
+            println!("Config dumped to {:?}", path);
+        }
+        return Ok(());
+    };
+
+    let conf = Arc::new(conf);
 
     if matches.is_present("check-config") {
         println!("Config loaded successfully");
         return Ok(());
     }
 
-    conf.initialize_logging();
+    conf.initialize_logging(&matches);
 
     let stats = Arc::new(stats::Stats::new());
 
+    if conf.expect_proxy {
+        info!("NOTE: Expecting PROXY protocol on streams");
+    }
+
+    let p = permit::Permit::new();
+
+    // Set up the stats server
     if let Some(ref stats_socket_listen_address) = conf.stats_socket_listen_address {
+        let server = stats_socket::StatsServer::new(Arc::clone(&stats), p.new_sub());
         if stats_socket_listen_address.starts_with('/')
             || stats_socket_listen_address.starts_with('.')
         {
+            info!(
+                "Stats socket listening on {:?}",
+                stats_socket_listen_address
+            );
             let listener = stats_socket::bind_unix_listener(
                 stats_socket_listen_address,
                 conf.stats_socket_mode.clone(),
@@ -500,8 +139,12 @@ async fn main() -> anyhow::Result<()> {
                     stats_socket_listen_address,
                 )
             })?;
-            tokio::spawn(stats_socket::stats_main_unix(listener, Arc::clone(&stats)));
+            tokio::spawn(server.run_unix(listener));
         } else {
+            info!(
+                "Stats socket listening on {:?}",
+                stats_socket_listen_address
+            );
             let listener = tokio::net::TcpListener::bind(stats_socket_listen_address)
                 .await
                 .with_context(|| {
@@ -510,50 +153,34 @@ async fn main() -> anyhow::Result<()> {
                         stats_socket_listen_address
                     )
                 })?;
-            tokio::spawn(stats_socket::stats_main_tcp(listener, Arc::clone(&stats)));
+            tokio::spawn(server.run_tcp(listener));
         }
     }
 
-    let listen_results = conf
-        .listen_address
-        .iter()
-        .map(|addr| {
-            let listener = if addr.is_ipv6() {
-                tokio::net::TcpSocket::new_v6().expect("failed to create IPv6 socket")
-            } else {
-                tokio::net::TcpSocket::new_v4().expect("failed to create IPv4 socket")
-            };
+    // Set up the main SOCKS server
+    let (_, p) = socks::run(Arc::clone(&conf), stats, p).await?;
 
-            listener
-                .set_reuseaddr(true)
-                .context("failed to set SO_REUSEADDR")?;
-
-            #[cfg(all(unix, not(any(target_os = "solaris"))))]
-            listener
-                .set_reuseport(conf.reuse_port)
-                .context("failed to set SO_REUSEPORT")?;
-
-            listener
-                .bind(*addr)
-                .with_context(|| format!("failed to bind to {:?}", addr))?;
-            info!("Listening on: {}", addr);
-
-            listener
-                .listen(LISTEN_BACKLOG)
-                .context("failed to listen on socket")
-        })
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .map(|listener| {
-            tokio::spawn(handle_connections(
-                listener,
-                Arc::clone(&conf),
-                Arc::clone(&stats),
-            ))
-        })
-        .collect::<futures::stream::FuturesUnordered<_>>()
-        .collect::<Vec<_>>()
-        .await;
-    info!("listen results: {:?}", listen_results);
+    // Shut down on signal (TODO: or if the socks server dies?)
+    any_shutdown_signal().await;
+    info!("got shutdown signal; attempting graceful shutdown");
+    let shutdown_start = std::time::Instant::now();
+    match p.revoke().try_wait_for(conf.shutdown_timeout) {
+        Ok(_) => debug!("shutdown finished in {:?}", shutdown_start.elapsed()),
+        Err(e) => warn!(
+            "shutdown timed out after {:?}: {:?}",
+            shutdown_start.elapsed(),
+            e
+        ),
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cli;
+
+    #[test]
+    fn test_debug_assert_cli() {
+        cli().debug_assert();
+    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -8,13 +8,13 @@ use derive_more::Display;
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpStream;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Mode {
     Local,
     Proxy,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Family {
     Unspec,
     Inet,
@@ -22,14 +22,14 @@ pub(crate) enum Family {
     Unix,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Transport {
     Empty,
     Stream,
     Dgram,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ProxyHeader {
     pub mode: Mode,
     pub family: Family,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,12 +1,10 @@
 use log::error;
-use std::error::Error;
 use std::io::Cursor;
 use std::net::{IpAddr, SocketAddr};
 
 use byteorder::NetworkEndian;
-use derive_more::Display;
-use tokio::io::AsyncReadExt;
-use tokio::net::TcpStream;
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Mode {
@@ -37,51 +35,52 @@ pub(crate) struct ProxyHeader {
     pub source_address: SocketAddr,
 }
 
-#[derive(Debug, Display)]
+#[derive(Debug, Error)]
 pub(crate) enum HeaderError {
+    #[error("Invalid magic bytes in PROXY protocol")]
     InvalidMagicBytes,
+    #[error("Invalid PROXY version {0}")]
     InvalidVersion(u8),
+    #[error("Invalid mode byte {0}")]
     InvalidMode(u8),
+    #[error("Invalid family byte {0}")]
     InvalidFamily(u8),
+    #[error("Invalid transport byte {0}")]
     InvalidTransport(u8),
+    #[error("Invalid variable data of length {0}")]
     InvalidVarData(u16),
-    IoError(tokio::io::Error),
+    #[error("I/O Error: {0}")]
+    Io(#[from] tokio::io::Error),
+    #[error("Unsupported family/address")]
     UnsupportedFamilyOrAddress,
 }
 
-impl Error for HeaderError {}
-
-impl From<tokio::io::Error> for HeaderError {
-    fn from(e: tokio::io::Error) -> HeaderError {
-        HeaderError::IoError(e)
-    }
-}
-
-pub(crate) async fn read_proxy_header(
-    socket: &mut TcpStream,
+/// Read the PROXY(v2) protocol
+pub(crate) async fn read_proxy_header<S>(
+    socket: &mut S,
     address: SocketAddr,
-) -> Result<ProxyHeader, HeaderError> {
+) -> Result<ProxyHeader, HeaderError>
+where
+    S: AsyncRead + Unpin + 'static,
+{
     let mut fixed_header = [0u8; 16];
     socket.read_exact(&mut fixed_header).await?;
     if fixed_header[..12] != *b"\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A" {
         return Err(HeaderError::InvalidMagicBytes);
     }
-    let version_command = fixed_header[13];
-    let family_address = fixed_header[14];
+    let version_command = fixed_header[12];
+    let family_address = fixed_header[13];
     let remaining_len =
-        byteorder::ReadBytesExt::read_u16::<NetworkEndian>(&mut &fixed_header[15..16])?;
-    dbg!(&remaining_len);
+        byteorder::ReadBytesExt::read_u16::<NetworkEndian>(&mut &fixed_header[14..16])?;
     let version = version_command >> 4;
     if version != 0x02 {
         return Err(HeaderError::InvalidVersion(version));
     }
-    dbg!(&version);
     let mode = match version_command & 0x0f {
         0x00 => Mode::Local,
         0x01 => Mode::Proxy,
         other => return Err(HeaderError::InvalidMode(other)),
     };
-    dbg!(&mode);
     let family = match family_address >> 4 {
         0x00 => Family::Unspec,
         0x01 => Family::Inet,
@@ -89,14 +88,12 @@ pub(crate) async fn read_proxy_header(
         0x03 => Family::Unix,
         other => return Err(HeaderError::InvalidFamily(other)),
     };
-    dbg!(&family);
     let transport = match family_address & 0x0f {
         0x00 => Transport::Empty,
         0x01 => Transport::Stream,
         0x02 => Transport::Dgram,
         other => return Err(HeaderError::InvalidTransport(other)),
     };
-    dbg!(&transport);
     let source_address = match family {
         Family::Unix => {
             error!("remaining data is {}", remaining_len);
@@ -104,7 +101,7 @@ pub(crate) async fn read_proxy_header(
         }
         Family::Inet => {
             if remaining_len != 12 {
-                error!("expected 96 bytes of address; got {:?}", remaining_len);
+                error!("expected 12 bytes of address; got {:?}", remaining_len);
                 return Err(HeaderError::InvalidVarData(remaining_len));
             }
             let mut buf = [0u8; 12];
@@ -119,8 +116,8 @@ pub(crate) async fn read_proxy_header(
         Family::Inet6 => {
             let mut buf = [0u8; 36];
             let mut ip_buf = [0u8; 16];
-            ip_buf.copy_from_slice(&buf[0..16]);
             socket.read_exact(&mut buf).await?;
+            ip_buf.copy_from_slice(&buf[0..16]);
             let source_addr = IpAddr::V6(ip_buf.into());
             let source_port =
                 byteorder::ReadBytesExt::read_u16::<NetworkEndian>(&mut &buf[32..34])?;
@@ -134,4 +131,65 @@ pub(crate) async fn read_proxy_header(
         transport,
         source_address,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_proxy_header;
+    use super::{Family, Mode, ProxyHeader, Transport};
+    use hex_literal::hex;
+
+    macro_rules! proxy_header_tests {
+        ($($label: ident: $value: expr, )*) => {
+            $(
+            #[tokio::test]
+            async fn $label() {
+                let (input, expected) = $value;
+                let raw = "0.0.0.1:1".parse().unwrap();
+                let mut r = std::io::Cursor::new(input);
+                let found = read_proxy_header(&mut r, raw).await.expect("should parse");
+                assert_eq!(expected, found);
+            }
+            )*
+        }
+    }
+
+    proxy_header_tests! {
+        ipv4_stream: (
+            hex!("0d0a0d0a000d0a515549540a 21 11 000c 08080808 0a0a0a0a 846c 0050"),
+            ProxyHeader {
+                mode: Mode::Proxy,
+                family: Family::Inet,
+                transport: Transport::Stream,
+                source_address: "8.8.8.8:33900".parse().unwrap()
+            }
+        ),
+        ipv4_dgram: (
+            hex!("0d0a0d0a000d0a515549540a 21 12 000c 08080808 0a0a0a0a 846c 0050"),
+            ProxyHeader {
+                mode: Mode::Proxy,
+                family: Family::Inet,
+                transport: Transport::Dgram,
+                source_address: "8.8.8.8:33900".parse().unwrap()
+            }
+        ),
+        ipv6_stream: (
+            hex!("0d0a0d0a000d0a515549540a 20 21 0024 2607f0d02901007e0000000000000003 fd00eaea000000000000000000000001 846c 0050"),
+            ProxyHeader {
+                mode: Mode::Local,
+                family: Family::Inet6,
+                transport: Transport::Stream,
+                source_address: "[2607:f0d0:2901:7e::3]:33900".parse().unwrap()
+            }
+        ),
+        ipv6_dgram: (
+            hex!("0d0a0d0a000d0a515549540a 20 22 0024 2607f0d02901007e0000000000000003 fd00eaea000000000000000000000001 ffff 0050"),
+            ProxyHeader {
+                mode: Mode::Local,
+                family: Family::Inet6,
+                transport: Transport::Dgram,
+                source_address: "[2607:f0d0:2901:7e::3]:65535".parse().unwrap()
+            }
+        ),
+    }
 }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -29,11 +29,14 @@ impl Reply {
         }
     }
 
-    pub async fn write_error<A: AsyncWrite + Unpin>(
+    pub async fn write_error<A>(
         &self,
         into: &mut A,
         version: Version,
-    ) -> Result<(), tokio::io::Error> {
+    ) -> Result<(), tokio::io::Error>
+    where
+        A: AsyncWrite + Unpin + 'static,
+    {
         match version {
             Version::Four => {
                 into.write_all(&[0x00, 0x5b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,14 +6,14 @@ use tokio::net::{TcpSocket, TcpStream};
 
 use crate::config::Config;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum Address {
     IpAddr(IpAddr),
     DomainName(String),
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum Version {
     #[serde(rename = "4")]
     Four,
@@ -21,7 +21,7 @@ pub enum Version {
     Five,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Request {
     pub address: Address,
     pub dport: u16,
@@ -36,12 +36,6 @@ impl Request {
             dport,
             ver,
             username,
-        }
-    }
-
-    pub fn set_username(&mut self, username: Option<String>) {
-        if username.is_some() {
-            self.username = username
         }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,7 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use log::debug;
-use serde_derive::Serialize;
+use serde::Serialize;
 use tokio::net::{TcpSocket, TcpStream};
 
 use crate::config::Config;
@@ -48,7 +48,7 @@ impl Request {
 
 pub enum Connection {
     Connected(TcpStream),
-    ConnectionNotAllowed,
+    NotAllowed,
     AddressNotSupported,
     SocksFailure,
 }
@@ -110,7 +110,7 @@ async fn connect_one(
             Connection::AddressNotSupported
         }
     } else {
-        Connection::ConnectionNotAllowed
+        Connection::NotAllowed
     };
     Ok(conn)
 }
@@ -133,14 +133,14 @@ impl Request {
                         Connection::AddressNotSupported => {
                             saw_not_supported = true;
                         }
-                        Connection::ConnectionNotAllowed => {
+                        Connection::NotAllowed => {
                             saw_not_allowed = true;
                         }
                         _ => {}
                     }
                 }
                 if saw_not_allowed {
-                    Connection::ConnectionNotAllowed
+                    Connection::NotAllowed
                 } else if saw_not_supported {
                     Connection::AddressNotSupported
                 } else {

--- a/src/socks.rs
+++ b/src/socks.rs
@@ -1,0 +1,481 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NetworkEndian};
+use futures::future::FutureExt;
+use futures::stream::StreamExt;
+use log::{debug, error, info, warn};
+use permit::Permit;
+use thiserror::Error;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::config::Config;
+use crate::reply::Reply;
+use crate::request::{Address, Connection, Request, Version};
+use crate::stats::Stats;
+
+const LISTEN_BACKLOG: u32 = 128;
+
+enum HandshakeResult {
+    Okay,
+    AuthenticatedAs(String),
+    Failed,
+    Version4([u8; 2]),
+}
+
+async fn authenticate_rfc1929(socket: &mut TcpStream) -> Result<Option<String>, tokio::io::Error> {
+    let mut buf = [0u8; 2];
+    socket.read_exact(&mut buf).await?;
+    // VER = 0x01
+    if buf[0] != 0x01 {
+        return Ok(None);
+    }
+    let mut username = vec![0u8; buf[1] as usize];
+    socket.read_exact(&mut username).await?;
+    let mut password_len = [0u8; 1];
+    socket.read_exact(&mut password_len).await?;
+    let mut password = vec![0u8; password_len[0] as usize];
+    socket.read_exact(&mut password).await?;
+    socket.write_all(&[0x1u8, 0x0u8]).await?;
+    Ok(Some(String::from_utf8_lossy(&username).into_owned()))
+}
+
+/// Perform the RFC1928 authentication handshake
+///
+/// Prerequisite: Nothing has been read from the socket yet
+///
+/// If returns HandshakeResult::Failed, the stream should be closed. Otherwise,
+/// we are (to some degree) authenticated.
+async fn handshake_auth(socket: &mut TcpStream) -> Result<HandshakeResult, tokio::io::Error> {
+    // If this is SOCKS4, the first byte is 0x04 and the second byte is actually not part of the
+    // handshake. Oops!
+    let mut init_buf = [0u8; 2];
+    socket.read_exact(&mut init_buf).await?;
+    if init_buf[0] == 0x04 {
+        return Ok(HandshakeResult::Version4(init_buf));
+    }
+    // If this is SOCKS5, the first byte is 0x05 and the second byte is the number of auth
+    // mechanisms supported
+    if init_buf[0] != 0x05 {
+        socket.write_all(&[0x05u8, 0xff]).await?;
+        return Ok(HandshakeResult::Failed);
+    }
+    let num_auths = init_buf[1];
+    if num_auths > 0xfe {
+        socket.write_all(&[0x05u8, 0xff]).await?;
+        return Ok(HandshakeResult::Failed);
+    }
+    // Each auth mechanism is a single byte
+    let mut auths = vec![0u8; num_auths as usize];
+    socket.read_exact(&mut auths).await?;
+    // Try more sophisticated (higher-valued) auth mechanisms first
+    auths.sort_by(|a, b| b.cmp(a));
+    for auth in auths {
+        if auth == 0u8 {
+            // 0x00 == unauthenticated. great
+            socket.write_all(&[0x5u8, 0x00u8]).await?;
+            return Ok(HandshakeResult::Okay);
+        } else if auth == 0x02u8 {
+            // 0x02 = username+password auth as per RFC1929
+            socket.write_all(&[0x5u8, 0x2u8]).await?;
+            if let Some(username) = authenticate_rfc1929(socket).await? {
+                return Ok(HandshakeResult::AuthenticatedAs(username));
+            } else {
+                warn!("1929 authentication failed; aborting");
+                socket.write_all(&[0x1u8, 0xffu8]).await?;
+            }
+        }
+    }
+    // if we get here, we didn't have any supported auth mechainisms. oops.
+    socket.write_all(&[0x5u8, 0xffu8]).await?;
+    Ok(HandshakeResult::Failed)
+}
+
+#[derive(Debug, Error)]
+enum RequestError {
+    #[error("Bad address type")]
+    BadAddressType,
+    #[error("I/O Error: {0}")]
+    Io(#[from] tokio::io::Error),
+}
+
+/// Read a SOCKSv4 or SOCKSv5 request from the stream
+async fn read_request(
+    socket: &mut TcpStream,
+    already_read: Option<[u8; 2]>,
+) -> Result<Option<Request>, RequestError> {
+    let (ver, cmd, addr_type) = if let Some(already_read) = already_read {
+        (already_read[0], already_read[1], 0x01u8)
+    } else {
+        let mut fixed_buf = [0u8; 4];
+        socket.read_exact(&mut fixed_buf).await?;
+        let ver = fixed_buf[0];
+        let cmd = fixed_buf[1];
+        let addr_type = fixed_buf[3];
+        (ver, cmd, addr_type)
+    };
+    let version = match ver {
+        4 => Version::Four,
+        5 => Version::Five,
+        _ => {
+            Reply::SocksFailure
+                .write_error(socket, Version::Five)
+                .await?;
+            return Ok(None);
+        }
+    };
+    let request = match version {
+        Version::Four => {
+            let mut buf = [0u8; 6];
+            socket.read_exact(&mut buf).await?;
+            let mut ip_buf = [0u8; 4];
+            ip_buf.copy_from_slice(&buf[2..6]);
+            let dport = NetworkEndian::read_u16(&buf[0..2]);
+            let ip_addr: Ipv4Addr = ip_buf.into();
+            let mut username = Vec::new();
+            let mut buf = [0u8; 1];
+            loop {
+                socket.read_exact(&mut buf).await?;
+                if buf[0] == 0x0 {
+                    break;
+                }
+                username.push(buf[0]);
+            }
+            let address = if ip_addr.octets()[0..3] == [0, 0, 0] {
+                let mut addr_buf = Vec::new();
+                loop {
+                    socket.read_exact(&mut buf).await?;
+                    if buf[0] == 0x0 {
+                        break;
+                    }
+                    addr_buf.push(buf[0]);
+                }
+                Address::DomainName(String::from_utf8_lossy(&addr_buf).into_owned())
+            } else {
+                Address::IpAddr(IpAddr::V4(ip_addr))
+            };
+            Request::new(
+                address,
+                dport,
+                version,
+                Some(String::from_utf8_lossy(&username).into_owned()),
+            )
+        }
+        Version::Five => {
+            let address = match addr_type {
+                0x01 => {
+                    let mut buf = [0u8; 4];
+                    socket.read_exact(&mut buf).await?;
+                    Address::IpAddr(IpAddr::V4(buf.into()))
+                }
+                0x03 => {
+                    let mut len_buf = [0u8; 1];
+                    socket.read_exact(&mut len_buf).await?;
+                    let mut name = vec![0u8; len_buf[0] as usize];
+                    socket.read_exact(&mut name).await?;
+                    Address::DomainName(String::from_utf8_lossy(&name).into_owned())
+                }
+                0x04 => {
+                    let mut buf = [0u8; 16];
+                    socket.read_exact(&mut buf).await?;
+                    Address::IpAddr(IpAddr::V6(buf.into()))
+                }
+                _ => return Err(RequestError::BadAddressType),
+            };
+            let mut port_buf = [0u8; 2];
+            socket.read_exact(&mut port_buf).await?;
+            let dport = NetworkEndian::read_u16(&port_buf);
+            Request::new(address, dport, version, None)
+        }
+    };
+    if cmd != 0x01 {
+        Reply::CommandNotSupported
+            .write_error(socket, Version::Five)
+            .await?;
+        return Ok(None);
+    }
+    Ok(Some(request))
+}
+
+async fn handle_one_connection(
+    mut socket: TcpStream,
+    address: SocketAddr,
+    config: Arc<Config>,
+    stats: &Stats,
+    conn_id: u64,
+) -> Result<bool, anyhow::Error> {
+    let address = if config.expect_proxy {
+        let header = match tokio::time::timeout(
+            config.proxy_protocol_timeout,
+            crate::proxy::read_proxy_header(&mut socket, address),
+        )
+        .await
+        {
+            Ok(h) => h.context("error reading PROXY protocol")?,
+            Err(e) => {
+                warn!("{}: timeout reading PROXY header: {:?}", conn_id, e);
+                stats.proxy_protocol_timeout();
+                return Ok(false);
+            }
+        };
+        if header.transport != crate::proxy::Transport::Stream {
+            anyhow::bail!("Invalid PROXY transport in header {:?}", header);
+        }
+        log::trace!("PROXY request {:?}", header);
+        header.source_address
+    } else {
+        address
+    };
+    debug!("{}: accepted connection from {:?}", conn_id, address);
+    let mut username = None;
+    let already_read = match handshake_auth(&mut socket)
+        .await
+        .context("error handshaking auth")?
+    {
+        HandshakeResult::Okay => None,
+        HandshakeResult::AuthenticatedAs(u) => {
+            stats.handshake_authenticated();
+            username = Some(u);
+            None
+        }
+        HandshakeResult::Failed => {
+            stats.handshake_failed();
+            debug!("{}: handshake failed", conn_id);
+            return Ok(false);
+        }
+        HandshakeResult::Version4(bytes) => Some(bytes),
+    };
+    stats.handshake_success();
+    debug!("{}: handshake succeeded", conn_id);
+    let request = read_request(&mut socket, already_read)
+        .await
+        .context("error reading request")?;
+    if let Some(mut request) = request {
+        request.set_username(username);
+        if let Some(ref u) = request.username {
+            debug!("{}: authenticated as {:?}", conn_id, u);
+        } else {
+            debug!("{}: unauthenticated", conn_id);
+        }
+        let version = request.ver;
+        stats.set_request(conn_id, &request).await;
+        let mut conn =
+            match tokio::time::timeout(config.connect_timeout, request.clone().connect(&config))
+                .await
+            {
+                Ok(c) => {
+                    stats.record_connection(&c);
+                    match c {
+                        Ok(Connection::Connected(c)) => c,
+                        Ok(Connection::NotAllowed) => {
+                            warn!("{}: denying connection to {:?}", conn_id, request);
+                            Reply::ConnectionNotAllowed
+                                .write_error(&mut socket, version)
+                                .await?;
+                            return Ok(false);
+                        }
+                        Ok(Connection::AddressNotSupported) => {
+                            warn!("{}: bad address family to {:?}", conn_id, request);
+                            Reply::AddressNotSupported
+                                .write_error(&mut socket, version)
+                                .await?;
+                            return Ok(false);
+                        }
+                        Ok(Connection::SocksFailure) => {
+                            warn!("{}: failure (resolution?) to {:?}", conn_id, request);
+                            Reply::SocksFailure
+                                .write_error(&mut socket, version)
+                                .await?;
+                            return Ok(false);
+                        }
+                        Err(e) => {
+                            Reply::NetworkUnreachable
+                                .write_error(&mut socket, version)
+                                .await?;
+                            warn!("error connecting: {:?}", e);
+                            return Ok(false);
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("{}: timeout connecting: {:?}", conn_id, e);
+                    Reply::TtlExpired.write_error(&mut socket, version).await?;
+                    stats.handshake_timeout();
+                    return Ok(false);
+                }
+            };
+        let remote_end = conn.peer_addr().context("error getting peer address")?;
+        let local_end = conn.local_addr().context("error getting local address")?;
+        stats.set_connection(conn_id, local_end, remote_end).await;
+        info!(
+            "{}: connected to {:?} from {:?}",
+            conn_id, remote_end, local_end
+        );
+        match version {
+            Version::Five => {
+                socket
+                    .write_all(&[
+                        0x05,
+                        0x00,
+                        0x00,
+                        match local_end {
+                            SocketAddr::V4(_) => 0x01,
+                            SocketAddr::V6(_) => 0x04,
+                        },
+                    ])
+                    .await?;
+                match local_end.ip() {
+                    IpAddr::V4(i) => socket.write_all(&i.octets()).await?,
+                    IpAddr::V6(i) => socket.write_all(&i.octets()).await?,
+                };
+                let mut buf = [0u8; 2];
+                NetworkEndian::write_u16(&mut buf, local_end.port());
+                socket
+                    .write_all(&buf)
+                    .await
+                    .context("error writing v5 response header")?;
+            }
+            Version::Four => {
+                socket
+                    .write_all(&[0x00, 0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+                    .await
+                    .context("error writing v4 response header")?;
+            }
+        }
+        let (stoc, ctos) = tokio::io::copy_bidirectional(&mut conn, &mut socket)
+            .await
+            .context("error copying body")?;
+        stats.record_traffic(stoc, ctos);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+async fn handle_one_connection_wrapper(
+    socket: TcpStream,
+    address: SocketAddr,
+    config: Arc<Config>,
+    stats: Arc<Stats>,
+    permit: Permit,
+) {
+    let conn_id = stats.start_request(address).await;
+    if let Some(timeout) = config.total_timeout {
+        match tokio::time::timeout(
+            timeout,
+            handle_one_connection(socket, address, config, &stats, conn_id),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {
+                stats.session_success();
+            }
+            Ok(Err(e)) => {
+                stats.session_error();
+                error!("error handling session {}: {:?}", conn_id, e);
+            }
+            Err(_) => {
+                warn!("session {} timed out!", conn_id);
+                stats.session_timeout();
+            }
+        }
+    } else {
+        match handle_one_connection(socket, address, config, &stats, conn_id).await {
+            Ok(_) => {
+                stats.session_success();
+            }
+            Err(e) => {
+                stats.session_error();
+                error!("error handling session {}: {:?}", conn_id, e);
+            }
+        }
+    }
+    info!("{}: finishing request", conn_id);
+    stats.finish_request(conn_id).await;
+    drop(permit);
+}
+
+async fn handle_connections(
+    listener: TcpListener,
+    conf: Arc<Config>,
+    stats: Arc<Stats>,
+    permit: Permit,
+) -> Result<(), tokio::io::Error> {
+    let outstanding = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let listen_permit = permit.new_sub();
+
+    let handled = tokio_stream::wrappers::TcpListenerStream::new(listener)
+        .take_until(listen_permit)
+        .filter_map(|socket| async { socket.ok().and_then(|s| s.peer_addr().ok().map(|p| (s, p))) })
+        .map(|(socket, address)| {
+            let my_config = Arc::clone(&conf);
+            let my_stats = Arc::clone(&stats);
+            let my_outstanding = Arc::clone(&outstanding);
+
+            my_outstanding.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(
+                handle_one_connection_wrapper(socket, address, my_config, my_stats, permit.clone())
+                    .map(move |r| {
+                        my_outstanding.fetch_sub(1, Ordering::SeqCst);
+                        r
+                    }),
+            );
+        })
+        .fold(0usize, |acc, _| async move { acc.wrapping_add(1) })
+        .await;
+    debug!("handled {} connections before getting shut down", handled);
+    Ok(())
+}
+
+// you have to be inside an async fn to call tokio::spawn, but actually this is entirely
+// synchronous
+pub async fn run(
+    conf: Arc<Config>,
+    stats: Arc<Stats>,
+    permit: Permit,
+) -> anyhow::Result<(Vec<tokio::task::JoinHandle<std::io::Result<()>>>, Permit)> {
+    let handles = conf
+        .listen_address
+        .iter()
+        .map(|addr| {
+            let listener = if addr.is_ipv6() {
+                tokio::net::TcpSocket::new_v6().expect("failed to create IPv6 socket")
+            } else {
+                tokio::net::TcpSocket::new_v4().expect("failed to create IPv4 socket")
+            };
+
+            listener
+                .set_reuseaddr(true)
+                .context("failed to set SO_REUSEADDR")?;
+
+            #[cfg(all(unix, not(any(target_os = "solaris"))))]
+            listener
+                .set_reuseport(conf.reuse_port)
+                .context("failed to set SO_REUSEPORT")?;
+
+            listener
+                .bind(*addr)
+                .with_context(|| format!("failed to bind to {:?}", addr))?;
+            info!("Listening on: {}", addr);
+
+            listener
+                .listen(LISTEN_BACKLOG)
+                .context("failed to listen on socket")
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .map(|listener| {
+            tokio::spawn(handle_connections(
+                listener,
+                Arc::clone(&conf),
+                Arc::clone(&stats),
+                permit.new_sub(),
+            ))
+        })
+        .collect::<Vec<tokio::task::JoinHandle<_>>>();
+    Ok((handles, permit))
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,3 +18,25 @@ where
         ser.serialize_str("unknown")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::serialize_system_time;
+    use serde::Serialize;
+    use std::time::{Duration, SystemTime};
+
+    #[derive(Serialize)]
+    struct Uut {
+        #[serde(serialize_with = "serialize_system_time")]
+        uut: SystemTime,
+    }
+
+    #[test]
+    fn test_serialize_system_time() {
+        let uut = Uut {
+            uut: std::time::UNIX_EPOCH + Duration::from_secs(1642138333),
+        };
+        let found = serde_json::to_string(&uut).unwrap();
+        assert!(found.contains(r#"{"uut":{"ts":1642138333.0,"ago":"#));
+    }
+}


### PR DESCRIPTION
 - bump a great many dependencies
 - break out the actual SOCKS logic into `socks.rs`
 - implement proper graceful shutdowns using `permit` instead of polling
 - add `--dump-config` to dump out the default config
 - clean up stats server logic
 - improve how logging is configured
 - fix PROXY protocol implementation
 - add a ton of tests
 - bump `edition` to 2021